### PR TITLE
Change level 1 memory result data type to match Qiskit

### DIFF
--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -920,7 +920,7 @@ def default_experiment_result_function(
             measurement_data = np.average(measurement_data, axis=0)
 
         # construct results object
-        exp_data = ExperimentResultData(memory=measurement_data)
+        exp_data = ExperimentResultData(memory=measurement_data.tolist())
         return ExperimentResult(
             shots=backend.options.shots,
             success=True,

--- a/releasenotes/notes/level1list-6564aec23c46bf7a.yaml
+++ b/releasenotes/notes/level1list-6564aec23c46bf7a.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The data type of memory data produced by :class:`~.DynamicsBackend` for
+    measurement level 1 was changed from a Numpy array to a list in order to
+    match the type documented for the ``ExperimentResultData`` class in Qiskit.
+    To get the old Numpy format back, it is sufficient to call ``numpy.array``
+    on the result data.


### PR DESCRIPTION
In Qiskit, it is specified that memory should be a list (https://github.com/Qiskit/qiskit/blob/b9d5c9c6aeb4568b6e9fba8943517ebed300886d/qiskit/result/models.py#L38). While most code can work with either lists or numpy arrays, some can not, including BackendSamplerV2 in Qiskit (see
https://github.com/qiskit-community/qiskit-experiments/issues/1487). Here the numpy array data is converted to a nested list using `tolist()`.