### PR TITLE
Switched to FakeQuitoV2 in the test

### DIFF
--- a/test/dynamics/pulse/test_pulse_to_signals.py
+++ b/test/dynamics/pulse/test_pulse_to_signals.py
@@ -23,7 +23,7 @@ from qiskit.pulse import Schedule
 from qiskit.pulse.transforms.canonicalization import block_to_schedule
 from qiskit import QiskitError
 
-from qiskit_ibm_runtime.fake_provider import FakeQuito
+from qiskit_ibm_runtime.fake_provider import FakeQuitoV2
 
 try:
     from jax import jit
@@ -345,7 +345,7 @@ class TestPulseToSignals(QiskitDynamicsTestCase):
         """Test correct parsing of schedule with barrier instructions."""
 
         # this example needs any backend with at least 2 qubits
-        backend = FakeQuito()
+        backend = FakeQuitoV2()
 
         with pulse.build(backend) as sched_block:
             pulse.play(pulse.Constant(duration=3, amp=0.5), pulse.DriveChannel(0))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Switched to FakeQuitoV2 in the test to match the latest version of [qiskit-ibm-runtime](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime)

### Details and comments

qiskit-ibm-runtime has removed FakeQuito since v0.31.0.
