### PR TITLE
Adjust DynamicsBackend level 2 result formatting to match BackendSamplerV2's expectations

### DIFF
--- a/qiskit_dynamics/backend/backend_utils.py
+++ b/qiskit_dynamics/backend/backend_utils.py
@@ -136,7 +136,7 @@ def _get_memory_slot_probabilities(
                 level = str(max_outcome_value)
             memory_slot_result[-(idx + 1)] = level
 
-        memory_slot_result = "".join(memory_slot_result)
+        memory_slot_result = hex(int("".join(memory_slot_result), 2))
         if memory_slot_result in memory_slot_probs:
             memory_slot_probs[memory_slot_result] += prob
         else:

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -882,7 +882,7 @@ def default_experiment_result_function(
 
         # construct results object
         exp_data = ExperimentResultData(
-            counts=counts, memory=memory_samples if backend.options.memory else None
+            counts=counts, memory=memory_samples.tolist() if backend.options.memory else None
         )
         return ExperimentResult(
             shots=backend.options.shots,


### PR DESCRIPTION
Qiskit Experiments 0.8.0 uses `qiskit_ibm_runtime.SamplerV2` to execute circuits by default and that passes the execution to `qiskit.primitives.BackendSamplerV2` for `DynamicsBackend`.

When `BackendSamplerV2` converts the results from `DynamicsBackend` into the `PubResult` format, it uses the result `memory` in an if statement to check if it is empty. For a list that works but for a numpy array an exception is raised about needing to use `all()` to check the truth value of an array. Here the memory data is converted from numpy array into a list using `tolist()` before being passed into the result object. (Note: the function generating this numpy array has a type annotation stating that it returns a list, so this could be changed at that level of the stack instead but that might require changing other things expecting a numpy array).

After checking that the result memory is not empty, `BackendSamplerV2` packs the state results into a `BitArray` and to do this it assumes that the memory results are formatted as hex strings but `DynamicsBackend` was returning binary strings with the format `"10101"`. Here the strings are converted to hex. It is not clear to me if Qiskit specifies that one format is required or the other or if both should be valid (and `BackendSamplerV2` really has the problem by not accepting the binary format). There could be downstream disruption if some code assumes `DynamicsBackend` returns the binary format. Additionally, does Dynamics support returning shots for higher levels up to 9? That would work the "binary" (really "decimal" at that point) format but forcing the casting to hex breaks it.

